### PR TITLE
Update fly.toml: force_https = true

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -19,6 +19,7 @@ port = 443
 [[services.ports]]
 handlers = ["http"]
 port = 80
+force_https = true
 
 [[services.tcp_checks]]
 grace_period = "1s"


### PR DESCRIPTION
Automatic HTTPS redirects
https://community.fly.io/t/new-feature-automatic-https-redirects/4442